### PR TITLE
Options, args, and commands are added in spread instead of array

### DIFF
--- a/src/cli-command.ts
+++ b/src/cli-command.ts
@@ -100,7 +100,7 @@ export class CliCommand {
     this.inheritOpts = opts.inheritOpts ?? true
     this.consumeUnknownOpts = opts.consumeUnknownOpts ?? false
     this.helpHandler = showHelp
-    this.withOptions([{
+    this.withOptions({
       name: ['-h', '--help'],
       description: 'Display help for command',
       hook: (value): void => {
@@ -109,7 +109,7 @@ export class CliCommand {
           process.exit(0)
         }
       }
-    }])
+    })
   }
 
   public withDescription(description: string): CliCommand {
@@ -117,7 +117,7 @@ export class CliCommand {
     return this
   }
 
-  public withArguments(args: Argument[]): CliCommand {
+  public withArguments(...args: Argument[]): CliCommand {
     for (const arg of args) {
       this.checkArgument(arg)
       if (this.args.some(a => a.name == arg.name)) {
@@ -130,7 +130,7 @@ export class CliCommand {
     return this
   }
 
-  public withOptions(options: Option[]): CliCommand {
+  public withOptions(...options: Option[]): CliCommand {
     for (const option of options) {
       this.checkOption(option)
       const name = this.getName(option)
@@ -153,7 +153,7 @@ export class CliCommand {
     return this
   }
 
-  public withSubCommands(commands: CliCommand[]): CliCommand {
+  public withSubCommands(...commands: CliCommand[]): CliCommand {
     for (const command of commands) {
       this.checkSubCommand(command)
       if (command.inheritOpts) {

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -4,17 +4,17 @@ import { CliCommand } from './cli-command'
 
 const cli = new CliCommand('demo')
   .withDescription('A test CLI that we can run from the command line.')
-  .withOptions([
+  .withOptions(
     { name: ['-v', '--verbose'], defaultValue: true },
     { name: ['-f', '--files'], args: [{ name: 'dest', required: true }, { name: 'files', variadic: true }] }
-  ])
+  )
   .withHandler(() => { null })
-  .withSubCommands([
+  .withSubCommands(
     new CliCommand('hello')
       .withDescription('Just say hello')
-      .withArguments([{ name: 'an-arg', required: true }])
-      .withOptions([{ name: ['-hi', '--hello'], description: 'This is in the subcommand' }])
+      .withArguments({ name: 'an-arg', required: true })
+      .withOptions({ name: ['-hi', '--hello'], description: 'This is in the subcommand' })
       .withHandler(() => { null })
-  ])
+  )
 
 cli.process(process.argv).then(null).catch(null)

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -22,7 +22,7 @@ const formatArguments = (args: ArgumentDefinition[]): string => {
     argStrings.push(argString)
   }
 
-  return argStrings.length ? argStrings.join(' ') : ''
+  return argStrings.length ? argStrings.join(' ') + ' ' : ''
 }
 
 const formatOptions = (opts: OptionDefinition[]): string => {
@@ -65,7 +65,7 @@ const formatOptions = (opts: OptionDefinition[]): string => {
 }
 
 const formatCommandUsage = (command: CommandDefinition): string => {
-  return `${command.name} ${formatArguments(command.args)} [options]`
+  return `${command.name} ${formatArguments(command.args)}[options]`
 }
 
 const formatSubCommands = (subCommands: CommandDefinition[]): string => {


### PR DESCRIPTION
<!--- Put a summary of your changes in the title -->

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Minibrams/1708995a4933a08f4838df0243926653/raw/cilly__feature-spread-command-config.json)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change needed? What problem does it solve? -->

## Related Issue
<!--- This repo only accepts pull requests related to open issues -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Unit tests, demo program? -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the contribution guidelines document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you inversify-express-utils for a great template! -->
