### PR TITLE
Added variadic argument terminators

### DIFF
--- a/src/cli-command.test.ts
+++ b/src/cli-command.test.ts
@@ -224,6 +224,32 @@ describe('CliCommand', () => {
     })
   })
   describe('parse()', () => {
+    it('should correctly parse terminated variadic arguments', () => {
+      const cmd = new CliCommand('test')
+        .withArguments(
+          { name: 'files', variadic: true },
+          { name: 'dirs', variadic: true }
+        )
+
+      const parsed = cmd.parse(['test', '1', '2', '3', '--', '4', '5', '6'], { raw: true })
+      expect(parsed.args.files).to.eql(['1', '2', '3'])
+      expect(parsed.args.dirs).to.eql(['4', '5', '6'])
+    })
+    it('should correctly parse terminated variadic option arguments', () => {
+      const cmd = new CliCommand('test')
+        .withOptions(
+          {
+            name: ['-e', '--enfo'], args: [
+              { name: 'files', variadic: true },
+              { name: 'dirs', variadic: true }
+            ]
+          }
+        )
+
+      const parsed = cmd.parse(['test', '-e', '1', '2', '3', '--', '4', '5', '6'], { raw: true })
+      expect(parsed.opts.enfo.files).to.eql(['1', '2', '3'])
+      expect(parsed.opts.enfo.dirs).to.eql(['4', '5', '6'])
+    })
     it('should throw an error when duplicate options are passed', () => {
       const cmd = new CliCommand('test').withOptions({ name: ['-s', '--same'] })
       const throwing = (): void => { cmd.parse(['test', '--same', '--same'], { raw: true }) }

--- a/src/cli-command.ts
+++ b/src/cli-command.ts
@@ -455,6 +455,11 @@ export class CliCommand {
     const args: string[] = []
 
     while (q[0] && !TokenParser.isOptionName(q[0])) {
+      if (TokenParser.isVariadicTerminator(q[0])) {
+        q.shift()
+        break
+      }
+
       args.push(q[0])
       q.shift()
     }

--- a/src/tokens/token-parser.test.ts
+++ b/src/tokens/token-parser.test.ts
@@ -194,4 +194,13 @@ describe('src/token-parser/token-parser.ts', () => {
       }
     })
   })
+  describe('Parser.isVariadicTerminator', () => {
+    it('should correctly identify terminators', () => {
+      expect(TokenParser.isVariadicTerminator('--')).to.be.true
+      expect(TokenParser.isVariadicTerminator('-')).to.be.false
+      expect(TokenParser.isVariadicTerminator('---')).to.be.false
+      expect(TokenParser.isVariadicTerminator('')).to.be.false
+      expect(TokenParser.isVariadicTerminator('--stop')).to.be.false
+    })
+  })
 })

--- a/src/tokens/token-parser.ts
+++ b/src/tokens/token-parser.ts
@@ -24,7 +24,7 @@ const isVariadic = (option: string): boolean => VARIADIC_SYNTAX.test(option)
 const isRequired = (option: string): boolean => matchEntireString(REQUIRED_VALUE_SYNTAX).test(option)
 const isOptional = (option: string): boolean => matchEntireString(OPTIONAL_VALUE_SYNTAX).test(option)
 const isValidCliOptionSignature = (signature: string): boolean => matchEntireString(OPTION_SIGNATURE_SYNTAX).test(signature)
-
+const isVariadicTerminator = (token: string): boolean => token === '--'
 /**
  * Capitalizes the first letter in a string
  * @param name The string to capitalize
@@ -64,5 +64,6 @@ export const TokenParser = {
   isOptional,
   isValidCliOptionSignature,
   capitalize,
-  toCamelCase
+  toCamelCase,
+  isVariadicTerminator
 }


### PR DESCRIPTION
<!--- Put a summary of your changes in the title -->

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Minibrams/1708995a4933a08f4838df0243926653/raw/cilly__feature-terminate-variadic-args.json)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change needed? What problem does it solve? -->

## Related Issue
Fixes #17 
<!--- This repo only accepts pull requests related to open issues -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Unit tests, demo program? -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the contribution guidelines document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you inversify-express-utils for a great template! -->
